### PR TITLE
Update azure-storage-blobs-integration.md - Remove semicolon

### DIFF
--- a/docs/storage/azure-storage-blobs-integration.md
+++ b/docs/storage/azure-storage-blobs-integration.md
@@ -23,7 +23,7 @@ In your app host project, register the Azure Blob Storage integration by chainin
 var builder = DistributedApplication.CreateBuilder(args);
 
 var blobs = builder.AddAzureStorage("storage")
-                   .RunAsEmulator();
+                   .RunAsEmulator()
                    .AddBlobs("blobs");
 
 builder.AddProject<Projects.ExampleProject>()


### PR DESCRIPTION
Remove semicolon which was causing error.

## Summary

In the code sample, there is an unnecessary semicolon after `RunAsEmulator`, which should be removed since `AddBlobs()` is called on the next line and is part of the same method chain.
